### PR TITLE
Tri du nom des auteurs dans l'ordre alphabétique

### DIFF
--- a/mémoire.tex
+++ b/mémoire.tex
@@ -1,7 +1,7 @@
 \documentclass{livre}
 
 \titre{Patchwork combinatoire de courbes algébriques}
-\auteur{Thomas \textsc{Mordant}, Raphaël \textsc{Alexandre} \\ Encadré par : Ilia \textsc{Itenberg}}
+\auteur{Raphaël \textsc{Alexandre}, Thomas \textsc{Mordant} \\ Encadré par : Ilia \textsc{Itenberg}}
 
 \begin{document}
 


### PR DESCRIPTION
Salut Raphaël !
Mes vacances se passent bien, et les tiennes ? Comme tu vois, je me suis décidé à créer un compte GitHub et à te soumettre une fork request. Rien de vital, juste l'ordre des noms des auteurs : les convenances veulent que, pour des chercheurs d'importance égale, leurs noms apparaissent dans l'ordre alphabétique. J'ai donc placé ton nom avant le mien.
À lundi !
Thomas
